### PR TITLE
Py3k interop

### DIFF
--- a/pyssss/GF256elt.py
+++ b/pyssss/GF256elt.py
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 class Callable:
     def __init__(self, anycallable):
         self.__call__ = anycallable
@@ -58,7 +60,7 @@ class GF256elt:
     
     return GF256elt(GF256elt.__exptable[p])
       
-  def __div__(self,other):
+  def __truediv__(self,other):
     if not isinstance(other,GF256elt):
       raise Exception()
     
@@ -115,10 +117,10 @@ class GF256elt:
     for i in xrange(1,GF):
       GF256elt.__exptable[i] = GF256elt.__exptable[i-1] * 2
       if GF256elt.__exptable[i] >= GF:
-  	GF256elt.__exptable[i] ^= PP
+        GF256elt.__exptable[i] ^= PP
 
       GF256elt.__exptable[i] &= 0xff
-      GF256elt.__logtable[GF256elt.__exptable[i]]= i	
+      GF256elt.__logtable[GF256elt.__exptable[i]]= i
       
   def generate_logexp_tables():
     """Generate logarithm and exponential tables for the GF(256) generator 0x03
@@ -153,8 +155,8 @@ class GF256elt:
     GF256elt.__logtable[0] = 0
 
   def dump_tables():
-    print GF256elt.__exptable
-    print GF256elt.__logtable
+    print(GF256elt.__exptable)
+    print(GF256elt.__logtable)
 
   generate_logexp_tables = Callable(generate_logexp_tables)
   generate_pplogexp_tables = Callable(generate_pplogexp_tables)

--- a/pyssss/GF256elt.py
+++ b/pyssss/GF256elt.py
@@ -102,6 +102,7 @@ class GF256elt:
   def __eq__(self,other):
     return self.__bytevalue == other.__bytevalue
 
+  @staticmethod
   def generate_pplogexp_tables(PP):
     """Generate logarithm and exponential tables for Gf(256) with a prime
        polynomial whose value is 'PP'."""
@@ -122,6 +123,7 @@ class GF256elt:
       GF256elt.__exptable[i] &= 0xff
       GF256elt.__logtable[GF256elt.__exptable[i]]= i
       
+  @staticmethod
   def generate_logexp_tables():
     """Generate logarithm and exponential tables for the GF(256) generator 0x03
        and the modulo polynomial x^8 + x^4 + x^3 + x + 1 (0x11b) as defined
@@ -154,13 +156,10 @@ class GF256elt:
     GF256elt.__exptable[255] = GF256elt.__exptable[0] 
     GF256elt.__logtable[0] = 0
 
+  @staticmethod
   def dump_tables():
     print(GF256elt.__exptable)
     print(GF256elt.__logtable)
-
-  generate_logexp_tables = Callable(generate_logexp_tables)
-  generate_pplogexp_tables = Callable(generate_pplogexp_tables)
-  dump_tables = Callable(dump_tables)
 
 ##
 ## Generate log/exp tables based on a prime polynomial

--- a/pyssss/GF256elt.py
+++ b/pyssss/GF256elt.py
@@ -115,7 +115,7 @@ class GF256elt:
     GF256elt.__logtable[0] = (1 - GF) & 0xff
     GF256elt.__exptable[0] = 1
 
-    for i in xrange(1,GF):
+    for i in range(1,GF):
       GF256elt.__exptable[i] = GF256elt.__exptable[i-1] * 2
       if GF256elt.__exptable[i] >= GF:
         GF256elt.__exptable[i] ^= PP

--- a/pyssss/PGF256.py
+++ b/pyssss/PGF256.py
@@ -45,10 +45,10 @@ class PGF256:
     
     coeffs = []
     
-    for i in xrange(0,minDeg):
+    for i in range(0,minDeg):
       coeffs.append(self.coeff(i) + other.coeff(i))
     
-    for i in xrange(minDeg,maxDeg):
+    for i in range(minDeg,maxDeg):
       if self.deg() > other.deg():
         coeffs.append(self.coeff(i))
       else:
@@ -70,12 +70,12 @@ class PGF256:
     
     coeffs = []
     
-    for i in xrange(0,minDeg + 1):
+    for i in range(0,minDeg + 1):
       coeffs.append(self.coeff(i) - other.coeff(i))
     
     zero = GF256elt(0)
     
-    for i in xrange(minDeg + 1,maxDeg + 1):
+    for i in range(minDeg + 1,maxDeg + 1):
       if self.deg() > other.deg():
         coeffs.append(self.coeff(i))
       else:
@@ -91,10 +91,10 @@ class PGF256:
     if not isinstance(other,PGF256):
       raise Exception()
 
-    rescoeffs = [GF256elt(0) for i in xrange(0,self.deg() + other.deg() + 1)]
+    rescoeffs = [GF256elt(0) for i in range(0,self.deg() + other.deg() + 1)]
     
-    for i in xrange(0,self.deg() + 1):
-      for j in xrange(0,other.deg() + 1):
+    for i in range(0,self.deg() + 1):
+      for j in range(0,other.deg() + 1):
         rescoeffs[i + j] += self.coeff(i) * other.coeff(j)
                     
     return PGF256(rescoeffs)
@@ -114,7 +114,7 @@ class PGF256:
     
     zero = GF256elt(0)
     
-    for i in xrange(0,self.deg() + 1):
+    for i in range(0,self.deg() + 1):
       c.append(self.coeff(i) + zero)
         
     return c

--- a/pyssss/PGF256.py
+++ b/pyssss/PGF256.py
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from GF256elt import GF256elt
 
 class PGF256:

--- a/pyssss/PGF256Interpolator.py
+++ b/pyssss/PGF256Interpolator.py
@@ -31,7 +31,7 @@ class PGF256Interpolator:
     # Check that all points have different X
     #
     
-    for i in xrange(0,len(points)):
+    for i in range(0,len(points)):
       if points[i][0] in map(lambda x: x[0],points[i+1:]):
         raise Exception("Duplicate point exception")
         
@@ -56,7 +56,7 @@ class PGF256Interpolator:
     
     result = PGF256([GF256elt(0)])
     
-    for j in xrange(0,len(points)):
+    for j in range(0,len(points)):
       result = result + (self.__Lj(points,j) * points[j][1])
 
     return result
@@ -64,7 +64,7 @@ class PGF256Interpolator:
   def __Lj(self,points,j):
     result = GF256elt(1)
     x = PGF256((GF256elt(0),GF256elt(1)))
-    for i in xrange(0,len(points)):
+    for i in range(0,len(points)):
       if j == i:
         continue
       

--- a/pyssss/PGF256Interpolator.py
+++ b/pyssss/PGF256Interpolator.py
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from GF256elt import GF256elt
 from PGF256 import PGF256
 

--- a/pyssss/PySSSS.py
+++ b/pyssss/PySSSS.py
@@ -34,7 +34,7 @@ def pickRandomPolynomial(degree,zero):
   
   # Pick coefficients for x^n with n < degree
   
-  for c in xrange(1,degree):
+  for c in range(1,degree):
     coeffs.append(GF256elt(random.randint(0,255)))
           
   # Pick non null coefficient for x^degree
@@ -46,15 +46,15 @@ def pickRandomPolynomial(degree,zero):
 
 def encodeByte(byte,n,k):
   # Allocate array to track duplicates
-  picked = [False for i in xrange(0,256)]
+  picked = [False for i in range(0,256)]
   
   # Pick a random polynomial
   P = pickRandomPolynomial(k-1,GF256elt(byte))
   
   # Generate the keys
-  keys = [b"" for i in xrange(0,n)]
+  keys = [b"" for i in range(0,n)]
   
-  for i in xrange(0,n):
+  for i in range(0,n):
 
     #        
     # Pick a not yet picked X value in [0,255],
@@ -97,7 +97,7 @@ def encode(data,outputs,k):
     
     charkeys = encodeByte(byte,n,k)
 
-    for i in xrange(0,n):
+    for i in range(0,n):
       outputs[i].write(charkeys[i])
 
 def decode(keys,output):
@@ -113,7 +113,7 @@ def decode(keys,output):
 
   while not eok:
     points = []
-    for i in xrange(0,len(keys)):
+    for i in range(0,len(keys)):
       while True:
         b = keys[i].read(1)
         if 0 == len(b):
@@ -150,19 +150,19 @@ if __name__ == "__main__":
   outputs = []
   n = 5
   k = 3
-  for i in xrange(n):
+  for i in range(n):
     outputs.append(StringIO.StringIO())
 
   encode(input,outputs,k)
 
-  for i in xrange(n):
+  for i in range(n):
     print(outputs[i].getvalue().encode('hex'))
 
   inputs = []
-  for i in xrange(k):
+  for i in range(k):
     inputs.append(outputs[i+1])
 
-  for i in xrange(k):
+  for i in range(k):
     inputs[i].seek(0)
 
   output = StringIO.StringIO()

--- a/pyssss/PySSSS.py
+++ b/pyssss/PySSSS.py
@@ -16,6 +16,8 @@
 #
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import random
 
 from GF256elt import GF256elt
@@ -50,7 +52,7 @@ def encodeByte(byte,n,k):
   P = pickRandomPolynomial(k-1,GF256elt(byte))
   
   # Generate the keys
-  keys = ["" for i in xrange(0,n)]
+  keys = [b"" for i in xrange(0,n)]
   
   for i in xrange(0,n):
 
@@ -154,7 +156,7 @@ if __name__ == "__main__":
   encode(input,outputs,k)
 
   for i in xrange(n):
-    print outputs[i].getvalue().encode('hex')
+    print(outputs[i].getvalue().encode('hex'))
 
   inputs = []
   for i in xrange(k):
@@ -165,4 +167,4 @@ if __name__ == "__main__":
 
   output = StringIO.StringIO()
   decode(inputs,output)  
-  print output.getvalue()
+  print(output.getvalue())

--- a/pyssss/PySSSS.py
+++ b/pyssss/PySSSS.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
+import binascii
 
 from GF256elt import GF256elt
 from PGF256 import PGF256
@@ -52,7 +53,7 @@ def encodeByte(byte,n,k):
   P = pickRandomPolynomial(k-1,GF256elt(byte))
   
   # Generate the keys
-  keys = [b"" for i in range(0,n)]
+  keys = [bytearray() for i in range(0,n)]
   
   for i in range(0,n):
 
@@ -68,8 +69,8 @@ def encodeByte(byte,n,k):
     while picked[pick] or pick == 0:
       # 0 values will be discarded but output it anyway with trailing garbage
       if pick == 0:
-        keys[i] += chr(0)
-        keys[i] += chr(random.randint(0,255))
+        keys[i].append(0)
+        keys[i].append(random.randint(0,255))
           
       pick = random.randint(1,255)
     
@@ -79,8 +80,8 @@ def encodeByte(byte,n,k):
     X = GF256elt(pick)
     Y = P.f(X)
     
-    keys[i] += chr(int(X))
-    keys[i] += chr(int(Y))
+    keys[i].append(int(X))
+    keys[i].append(int(Y))
 
   return keys
 
@@ -145,18 +146,18 @@ def decode(keys,output):
     output.write(chr(byte))
 
 if __name__ == "__main__":
-  import StringIO
-  input = StringIO.StringIO("Too many secrets, Marty!")
+  from io import BytesIO
+  input = BytesIO(b"Too many secrets, Marty!")
   outputs = []
   n = 5
   k = 3
   for i in range(n):
-    outputs.append(StringIO.StringIO())
+    outputs.append(BytesIO())
 
   encode(input,outputs,k)
 
   for i in range(n):
-    print(outputs[i].getvalue().encode('hex'))
+    print(binascii.hexlify(outputs[i].getvalue()))
 
   inputs = []
   for i in range(k):
@@ -165,6 +166,6 @@ if __name__ == "__main__":
   for i in range(k):
     inputs[i].seek(0)
 
-  output = StringIO.StringIO()
+  output = BytesIO()
   decode(inputs,output)  
   print(output.getvalue())

--- a/pyssss/PySSSS.py
+++ b/pyssss/PySSSS.py
@@ -143,11 +143,11 @@ def decode(keys,output):
 
     # Decode next byte
     byte = interpolator.interpolate(points).f(zero)
-    output.write(chr(byte))
+    output.write(bytearray((int(byte),)))
 
 if __name__ == "__main__":
   from io import BytesIO
-  input = BytesIO(b"Too many secrets, Marty!")
+  input = BytesIO("Too many secrets, Marty!".encode('UTF-8'))
   outputs = []
   n = 5
   k = 3
@@ -157,7 +157,7 @@ if __name__ == "__main__":
   encode(input,outputs,k)
 
   for i in range(n):
-    print(binascii.hexlify(outputs[i].getvalue()))
+    print(binascii.hexlify(outputs[i].getvalue()).decode('UTF-8'))
 
   inputs = []
   for i in range(k):
@@ -168,4 +168,4 @@ if __name__ == "__main__":
 
   output = BytesIO()
   decode(inputs,output)  
-  print(output.getvalue())
+  print(output.getvalue().decode('UTF-8'))


### PR DESCRIPTION
These changes make the code interoperable with Python 2 and Python 3.  In Py3k, operations happen on bytes objects rather than strings (which makes sense).
